### PR TITLE
fix: loading animation for loop uses hard coded value in condition

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,10 +15,10 @@ loading_animation_frames = [
 ]
 
 def loading(stop_loading_thread):
-    i = 0
-
+    
     while not stop_loading_thread.is_set():
-        for char in '|/-\\':
+        i = 0
+        for char in loading_animation_frames:
             print('thinking ' + loading_animation_frames[i % len(loading_animation_frames)], end="\r")
             time.sleep(.125)
             i += 1


### PR DESCRIPTION
# Overview
The loading animation for loop uses a hard-coded value when looping through the animation frames when it should use the variable that holds the animation frames itself

## Changes
- Update for loop conditional inside `loading()` function